### PR TITLE
Update bottom navigation UI to match Figma design)

### DIFF
--- a/app/src/main/java/com/example/yedimap/MainActivity.kt
+++ b/app/src/main/java/com/example/yedimap/MainActivity.kt
@@ -1,5 +1,10 @@
 package com.example.yedimap
 
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
 import androidx.compose.material3.ExperimentalMaterial3Api
 import android.os.Bundle
 import androidx.activity.ComponentActivity
@@ -9,6 +14,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.NavigationBarItemDefaults
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
@@ -27,6 +33,11 @@ import com.example.yedimap.ui.navigation.YediMapNavGraph
 import com.example.yedimap.ui.splash.SplashScreen
 import com.example.yedimap.ui.theme.YediMapTheme
 import kotlinx.coroutines.delay
+import com.example.yedimap.ui.theme.PurpleSplash
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.unit.dp
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -75,17 +86,15 @@ fun YediMapApp() {
             )
         },
         bottomBar = {
-            NavigationBar {
+            NavigationBar(
+                containerColor = PurpleSplash,  // #52489C arka plan
+                contentColor = Color.White,
+                        modifier = Modifier.height(75.dp)
+            ) {
                 Screen.bottomNavItems.forEach { screen ->
                     val selected = currentRoute == screen.route
+
                     NavigationBarItem(
-                        icon = {
-                            Icon(
-                                imageVector = screen.icon,
-                                contentDescription = stringResource(id = screen.titleRes)
-                            )
-                        },
-                        label = { Text(text = stringResource(id = screen.titleRes)) },
                         selected = selected,
                         onClick = {
                             if (!selected) {
@@ -97,7 +106,45 @@ fun YediMapApp() {
                                     restoreState = true
                                 }
                             }
-                        }
+                        },
+                        icon = {
+                            // Seçili ikonda mor yuvarlak + hafif gölge efekti
+                            Box(
+                                modifier = Modifier.size(45.dp),
+                                contentAlignment = Alignment.Center
+                            ) {
+                                if (selected) {
+                                    Box(
+                                        modifier = Modifier
+                                            .matchParentSize()
+                                            .shadow(
+                                                elevation = 8.dp,
+                                                shape = CircleShape,
+                                                clip = false
+                                            )
+                                            .background(
+                                                color = Color(0xFF3E2F7D),
+                                                shape = CircleShape
+                                            )
+                                    )
+                                }
+
+                                Icon(
+                                    imageVector = screen.icon,
+                                    contentDescription = stringResource(id = screen.titleRes),
+                                    tint = Color.White,
+                                    modifier = Modifier.size(28.dp)
+                                )
+                            }
+                        },
+
+                        colors = NavigationBarItemDefaults.colors(
+                            selectedIconColor = Color.White,
+                            unselectedIconColor = Color.White.copy(alpha = 0.8f),
+                            selectedTextColor = Color.White,
+                            unselectedTextColor = Color.White.copy(alpha = 0.8f),
+                            indicatorColor = Color.Transparent // default pill'i kapat
+                        )
                     )
                 }
             }
@@ -108,4 +155,5 @@ fun YediMapApp() {
             modifier = Modifier.padding(innerPadding)
         )
     }
+
 }

--- a/app/src/main/java/com/example/yedimap/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/yedimap/ui/home/HomeScreen.kt
@@ -1,0 +1,18 @@
+package com.example.yedimap.ui.home
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+@Composable
+fun HomeScreen() {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(text = "Home Screen")
+    }
+}

--- a/app/src/main/java/com/example/yedimap/ui/navigation/Screen.kt
+++ b/app/src/main/java/com/example/yedimap/ui/navigation/Screen.kt
@@ -7,12 +7,19 @@ import androidx.compose.material.icons.filled.Notifications
 import androidx.compose.material.icons.filled.Schedule
 import androidx.compose.ui.graphics.vector.ImageVector
 import com.example.yedimap.R
+import androidx.compose.material.icons.filled.Home
 
 sealed class Screen(
     val route: String,
     @StringRes val titleRes: Int,
     val icon: ImageVector
 ) {
+    object Home : Screen(
+        route = "home",
+        titleRes = R.string.nav_home,   // bunu az sonra ekleyeceğiz
+        icon = Icons.Filled.Home
+    )
+
     object Map : Screen(
         route = "map",
         titleRes = R.string.nav_map,
@@ -32,6 +39,5 @@ sealed class Screen(
     )
 
     companion object {
-        val bottomNavItems = listOf(Map, Schedule, Notifications)
-    }
+        val bottomNavItems = listOf(Home, Map, Schedule, Notifications)    }
 }

--- a/app/src/main/java/com/example/yedimap/ui/navigation/YediMapNavGraph.kt
+++ b/app/src/main/java/com/example/yedimap/ui/navigation/YediMapNavGraph.kt
@@ -8,6 +8,7 @@ import androidx.navigation.compose.composable
 import com.example.yedimap.ui.map.MapScreen
 import com.example.yedimap.ui.notifications.NotificationsScreen
 import com.example.yedimap.ui.schedule.ScheduleScreen
+import com.example.yedimap.ui.home.HomeScreen
 
 @Composable
 fun YediMapNavGraph(
@@ -16,9 +17,12 @@ fun YediMapNavGraph(
 ) {
     NavHost(
         navController = navController,
-        startDestination = Screen.Map.route,
+        startDestination = Screen.Home.route,
         modifier = modifier
     ) {
+        composable(Screen.Home.route) {
+            HomeScreen()
+        }
         composable(Screen.Map.route) {
             MapScreen()
         }
@@ -29,4 +33,5 @@ fun YediMapNavGraph(
             NotificationsScreen()
         }
     }
+
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,6 +1,7 @@
 <resources>
     <string name="app_name">YediMap</string>
 
+    <string name="nav_home">Home</string>
     <string name="nav_map">Map</string>
     <string name="nav_schedule">Schedule</string>
     <string name="nav_notifications">Notifications</string>


### PR DESCRIPTION
- Converted bottom nav to icon-only layout
- Reduced bar height (60dp)
- Added selected icon background circle + shadow effect
- Applied new purple background (#52489C)
- Increased icon sizes for better visibility
- Cleaned up NavigationBarItem implementation