### PR TITLE
Add My Profile screen and basic navigation

### DIFF
--- a/app/src/main/java/com/example/yedimap/ui/myprofile/MyProfileScreen.kt
+++ b/app/src/main/java/com/example/yedimap/ui/myprofile/MyProfileScreen.kt
@@ -1,0 +1,128 @@
+package com.example.yedimap.ui.myprofile
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.outlined.Edit
+import androidx.compose.material3.Divider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.yedimap.R
+
+private val ProfilePurple = Color(0xFF614184)
+
+@Composable
+fun MyProfileScreen(
+    onBackClick: () -> Unit = {}
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color.White)
+            .padding(horizontal = 24.dp)
+    ) {
+        IconButton(
+            onClick = onBackClick,
+            modifier = Modifier.padding(top = 12.dp)
+        ) {
+            Icon(
+                imageVector = Icons.Default.ArrowBack,
+                contentDescription = "Back",
+                tint = ProfilePurple
+            )
+        }
+
+        Spacer(modifier = Modifier.height(12.dp))
+
+        Text(
+            text = "My Profile",
+            color = ProfilePurple,
+            fontSize = 30.sp,
+            fontWeight = FontWeight.Medium,
+            modifier = Modifier.align(Alignment.CenterHorizontally)
+        )
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        Box(
+            modifier = Modifier
+                .size(140.dp)
+                .align(Alignment.CenterHorizontally),
+            contentAlignment = Alignment.Center
+        ) {
+            Image(
+                painter = painterResource(id = R.drawable.profile_placeholder),
+                contentDescription = "Profile Image",
+                modifier = Modifier
+                    .size(280.dp)
+                    .clip(CircleShape)
+            )
+
+            Box(
+                modifier = Modifier
+                    .size(250.dp)
+                    .clip(CircleShape)
+                    .border(
+                        width = 4.dp,
+                        color = ProfilePurple,
+                        shape = CircleShape
+                    )
+            )
+
+            Icon(
+                imageVector = Icons.Outlined.Edit,
+                contentDescription = "Edit",
+                tint = ProfilePurple,
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .offset(x = 6.dp, y = (-6).dp)
+            )
+        }
+
+        Spacer(modifier = Modifier.height(60.dp))
+
+        ProfileField(title = "NAME", value = "Selin Yılmaz")
+        ProfileField(title = "EMAIL", value = "selin.yilmaz@std.yeditepe.edu.tr")
+        ProfileField(title = "FACULTY", value = "Faculty of Fine Arts")
+        ProfileField(title = "PHONE", value = "+90 532 654 21 89")
+    }
+}
+
+@Composable
+private fun ProfileField(title: String, value: String) {
+    Column(modifier = Modifier.fillMaxWidth()) {
+        Text(
+            text = title,
+            fontSize = 18.sp,
+            fontWeight = FontWeight.Bold,
+            color = Color.Black
+        )
+
+        Spacer(modifier = Modifier.height(4.dp))
+
+        Text(
+            text = value,
+            fontSize = 16.sp,
+            color = Color.DarkGray
+        )
+
+        Spacer(modifier = Modifier.height(12.dp))
+
+        Divider(color = Color.LightGray)
+        Spacer(modifier = Modifier.height(20.dp))
+    }
+}

--- a/app/src/main/java/com/example/yedimap/ui/navigation/Screen.kt
+++ b/app/src/main/java/com/example/yedimap/ui/navigation/Screen.kt
@@ -8,6 +8,7 @@ import androidx.compose.material.icons.filled.Schedule
 import androidx.compose.ui.graphics.vector.ImageVector
 import com.example.yedimap.R
 import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.Person
 
 sealed class Screen(
     val route: String,
@@ -36,6 +37,12 @@ sealed class Screen(
         route = "notifications",
         titleRes = R.string.nav_notifications,
         icon = Icons.Filled.Notifications
+    )
+
+    object MyProfile : Screen(
+        route = "my_profile",
+        titleRes = R.string.nav_my_profile, // bunu strings.xml'e ekleyeceğiz
+        icon = Icons.Filled.Person // ikon zorunlu olduğu için veriyoruz
     )
 
     companion object {

--- a/app/src/main/java/com/example/yedimap/ui/navigation/YediMapNavGraph.kt
+++ b/app/src/main/java/com/example/yedimap/ui/navigation/YediMapNavGraph.kt
@@ -9,6 +9,7 @@ import com.example.yedimap.ui.map.MapScreen
 import com.example.yedimap.ui.notifications.NotificationsScreen
 import com.example.yedimap.ui.schedule.ScheduleScreen
 import com.example.yedimap.ui.home.HomeScreen
+import com.example.yedimap.ui.myprofile.MyProfileScreen
 
 @Composable
 fun YediMapNavGraph(
@@ -21,7 +22,9 @@ fun YediMapNavGraph(
         modifier = modifier
     ) {
         composable(Screen.Home.route) {
-            HomeScreen()
+            HomeScreen(onProfileClick = {
+                navController.navigate(Screen.MyProfile.route)
+            })
         }
         composable(Screen.Map.route) {
             MapScreen()
@@ -31,6 +34,9 @@ fun YediMapNavGraph(
         }
         composable(Screen.Notifications.route) {
             NotificationsScreen()
+        }
+        composable(Screen.MyProfile.route) {
+            MyProfileScreen(onBackClick = { navController.popBackStack() })
         }
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,4 +5,5 @@
     <string name="nav_map">Map</string>
     <string name="nav_schedule">Schedule</string>
     <string name="nav_notifications">Notifications</string>
+    <string name="nav_my_profile">My Profile</string>
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.11.2"
+agp = "8.13.2"
 kotlin = "2.0.21"
 coreKtx = "1.17.0"
 junit = "4.13.2"


### PR DESCRIPTION
This PR adds the My Profile screen UI.

Includes:
- My Profile screen with mock user data
- Home screen profile icon navigation
- Edit icon placement update
- Temporary static data (will be connected to login/signup later)

Note:
Bottom navigation interaction with profile screen will be improved in a future task.