### PR TITLE
Add Settings screen and connect it to drawer navigation

### DIFF
--- a/app/src/main/java/com/example/yedimap/MainActivity.kt
+++ b/app/src/main/java/com/example/yedimap/MainActivity.kt
@@ -111,7 +111,8 @@ fun YediMapApp() {
     val bottomBarHiddenRoutes = setOf(
         "my_profile",
         "drawer",
-        "cafeteria"
+        "cafeteria",
+        Screen.Settings.route
     )
 
     val shouldShowBottomBar = currentRoute !in bottomBarHiddenRoutes

--- a/app/src/main/java/com/example/yedimap/ui/drawer/DrawerMenu.kt
+++ b/app/src/main/java/com/example/yedimap/ui/drawer/DrawerMenu.kt
@@ -34,10 +34,12 @@ private val DrawerPurple = Color(0xFF614184)
 @Composable
 fun DrawerMenu(
     modifier: Modifier = Modifier,
-    name: String = "Kutay Büyükboyacı",
-    email: String = "kutay.buyukboyaci@std.yeditepe.edu.tr",
+    name: String = "Sadettin Saran",
+    email: String = "sadettin.saran@std.yeditepe.edu.tr",
     onClose: () -> Unit = {},
-    onMyProfileClick: () -> Unit = {}
+    onMyProfileClick: () -> Unit = {},
+    onSettingsClick: () -> Unit = {}
+
 ) {
     Column(
         modifier = modifier
@@ -114,7 +116,11 @@ fun DrawerMenu(
         DrawerItem(icon = Icons.Outlined.BookmarkBorder, title = "Saved Places")
         Spacer(modifier = Modifier.height(12.dp))
 
-        DrawerItem(icon = Icons.Outlined.Settings, title = "Settings")
+        DrawerItem(
+            icon = Icons.Outlined.Settings,
+            title = "Settings",
+            onClick = onSettingsClick
+        )
 
         Spacer(modifier = Modifier.weight(1f))
 

--- a/app/src/main/java/com/example/yedimap/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/yedimap/ui/home/HomeScreen.kt
@@ -35,7 +35,8 @@ fun HomeScreen(
     onFilterClick: () -> Unit = {},
     onProfileClick: () -> Unit = {},
     onCafeteriaClick: () -> Unit = {},
-    onDrawerStateChange: (Boolean) -> Unit = {}
+    onDrawerStateChange: (Boolean) -> Unit = {},
+    onSettingsClick: () -> Unit = {}
 ) {
     // ✅ Drawer state
     val drawerState = rememberDrawerState(initialValue = DrawerValue.Closed)
@@ -47,11 +48,24 @@ fun HomeScreen(
     ModalNavigationDrawer(
         drawerState = drawerState,
         drawerContent = {
-            DrawerMenu(onClose = { scope.launch { drawerState.close() } },
+
+            DrawerMenu(
+                onClose = {
+                    scope.launch { drawerState.close() }
+                },
                 onMyProfileClick = {
+                    scope.launch { drawerState.close() }
                     onProfileClick()
-                })
+                },
+                onSettingsClick = {
+                    scope.launch { drawerState.close() }
+                    onSettingsClick()
+                }
+            )
+
+
         }
+
     ) {
         // ✅ Senin mevcut Home UI aynen burada
         Column(

--- a/app/src/main/java/com/example/yedimap/ui/navigation/Screen.kt
+++ b/app/src/main/java/com/example/yedimap/ui/navigation/Screen.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import com.example.yedimap.R
 import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.outlined.Settings
 
 sealed class Screen(
     val route: String,
@@ -44,6 +45,13 @@ sealed class Screen(
         titleRes = R.string.nav_my_profile, // bunu strings.xml'e ekleyeceğiz
         icon = Icons.Filled.Person // ikon zorunlu olduğu için veriyoruz
     )
+
+    object Settings : Screen(
+        route = "settings",
+        titleRes = R.string.nav_settings,
+        icon = Icons.Outlined.Settings
+    )
+
 
     companion object {
         val bottomNavItems = listOf(Home, Map, Schedule, Notifications)    }

--- a/app/src/main/java/com/example/yedimap/ui/navigation/YediMapNavGraph.kt
+++ b/app/src/main/java/com/example/yedimap/ui/navigation/YediMapNavGraph.kt
@@ -11,6 +11,7 @@ import com.example.yedimap.ui.notifications.NotificationsScreen
 import com.example.yedimap.ui.schedule.ScheduleScreen
 import com.example.yedimap.ui.home.HomeScreen
 import com.example.yedimap.ui.myprofile.MyProfileScreen
+import com.example.yedimap.ui.settings.SettingsScreen
 
 @Composable
 fun YediMapNavGraph(
@@ -29,7 +30,8 @@ fun YediMapNavGraph(
                 },
                 onCafeteriaClick = {
                     navController.navigate("cafeteria")
-                }
+                },
+                onSettingsClick = { navController.navigate(Screen.Settings.route) }
             )
         }
         composable(Screen.Map.route) {
@@ -38,6 +40,7 @@ fun YediMapNavGraph(
         composable(Screen.Schedule.route) {
             ScheduleScreen()
         }
+
         composable(Screen.Notifications.route) {
             NotificationsScreen()
         }
@@ -49,6 +52,7 @@ fun YediMapNavGraph(
                 onBackClick = { navController.popBackStack() }
             )
         }
+
     }
 
 }

--- a/app/src/main/java/com/example/yedimap/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/example/yedimap/ui/settings/SettingsScreen.kt
@@ -1,0 +1,136 @@
+package com.example.yedimap.ui.settings
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.ArrowBack
+import androidx.compose.material.icons.outlined.ChevronRight
+import androidx.compose.material.icons.outlined.FilterAlt
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+private val BgPurple = Color(0xFFE9E2F2)
+private val HomePurple = Color(0xFF614184)
+
+@Composable
+fun SettingsScreen(
+    onBackClick: () -> Unit = {},
+    onFilterClick: () -> Unit = {}
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(BgPurple)
+            .padding(horizontal = 18.dp)
+    ) {
+
+        // 🔹 Top Row: Back + Title
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 16.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            IconButton(onClick = onBackClick) {
+                Icon(
+                    imageVector = Icons.Outlined.ArrowBack,
+                    contentDescription = "Back",
+                    tint = HomePurple
+                )
+            }
+
+            Text(
+                text = "Settings",
+                color = HomePurple,
+                fontSize = 20.sp,
+                fontWeight = FontWeight.Medium
+            )
+        }
+
+        // 🔹 Filter (Settings başlığının ALTINDA – sağda)
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 6.dp, end = 4.dp),
+            horizontalArrangement = Arrangement.End,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(
+                imageVector = Icons.Outlined.FilterAlt,
+                contentDescription = "Filter",
+                tint = HomePurple,
+                modifier = Modifier.size(22.dp)
+            )
+            Spacer(modifier = Modifier.width(6.dp))
+            Text(
+                text = "Filter",
+                color = HomePurple,
+                fontSize = 18.sp,
+                fontWeight = FontWeight.Medium
+            )
+        }
+
+        Spacer(modifier = Modifier.height(28.dp))
+
+        SettingsItem(title = "About YediMap")
+        Spacer(modifier = Modifier.height(24.dp))
+
+        SettingsItem(title = "Profile Information")
+        Spacer(modifier = Modifier.height(24.dp))
+
+        SettingsItem(title = "Schedule")
+        Spacer(modifier = Modifier.height(24.dp))
+
+        SettingsItem(title = "Language")
+        Spacer(modifier = Modifier.height(24.dp))
+
+        SettingsItem(title = "Log Out")
+    }
+}
+
+
+@Composable
+private fun SettingsItem(
+    title: String,
+    onClick: () -> Unit = {} // şimdilik pasif
+) {
+    Surface(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(52.dp),
+        color = HomePurple,
+        shape = RoundedCornerShape(12.dp),
+        tonalElevation = 0.dp,
+        shadowElevation = 0.dp
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = 16.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = title,
+                color = Color.White,
+                fontSize = 16.sp,
+                fontWeight = FontWeight.SemiBold
+            )
+            Spacer(modifier = Modifier.weight(1f))
+            Icon(
+                imageVector = Icons.Outlined.ChevronRight,
+                contentDescription = "Go",
+                tint = Color.White
+            )
+        }
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,4 +6,5 @@
     <string name="nav_schedule">Schedule</string>
     <string name="nav_notifications">Notifications</string>
     <string name="nav_my_profile">My Profile</string>
+    <string name="nav_settings">Settings</string>
 </resources>


### PR DESCRIPTION
This PR introduces the Settings screen and integrates it with the drawer menu.

What’s included:
- New Settings screen UI based on Figma
- Drawer menu navigation to Settings
- Bottom navigation bar hidden on Settings screen
- Filter icon placement aligned with design
- Logout item UI added