### PR TITLE
Fix crash by adding Settings route to NavGraph

### DIFF
--- a/app/src/main/java/com/example/yedimap/ui/navigation/YediMapNavGraph.kt
+++ b/app/src/main/java/com/example/yedimap/ui/navigation/YediMapNavGraph.kt
@@ -40,6 +40,11 @@ fun YediMapNavGraph(
         composable(Screen.Schedule.route) {
             ScheduleScreen()
         }
+        composable(Screen.Settings.route) {
+            SettingsScreen(
+                onBackClick = { navController.popBackStack() }
+            )
+        }
 
         composable(Screen.Notifications.route) {
             NotificationsScreen()


### PR DESCRIPTION
Settings screen was accessible from drawer but missing in NavGraph

Added composable(Screen.Settings.route) mapping to prevent crash